### PR TITLE
Vite is exposed to network and let through docker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ docker compose -f compose.dev.yaml up -d
 docker compose -f compose.dev.yaml exec workspace bash
 composer install
 npm install
-npm run dev
+npm run dev -- --host
 ```
 
 4. Run Migrations:

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -59,6 +59,8 @@ services:
         XDEBUG_IDE_KEY: ${XDEBUG_IDE_KEY:-DOCKER}
         XDEBUG_LOG: /dev/stdout
         XDEBUG_LOG_LEVEL: 0
+    ports:
+      - '${VITE_PORT:-5173}:${VITE_PORT:-5173}'
     tty: true  # Enables an interactive terminal
     stdin_open: true  # Keeps standard input open for 'docker exec'
     env_file:


### PR DESCRIPTION
First of all, thanks for such a docker configuration. I found it on docker's official website. I started using it with my Laravel 11.x application. However, I encountered a problem when tried to run "npm run dev" command. I saw errors in console log in the browser that assets are not found via 5173, while sail did not have this problem. So, with my investigation, I found out that we can fix that in two steps:
1. Network was not exposed. We have to instruct vite to expose port with "npm run dev -- --host". This is the safest solution so far in my opinion than editing vite's configration file to set exposing as default behaviour.
2. In dockerfile for dev environment, port 5173 has to be forwarded.