### PR TITLE
Vite is exposed to network and let through docker.

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -59,6 +59,8 @@ services:
         XDEBUG_IDE_KEY: ${XDEBUG_IDE_KEY:-DOCKER}
         XDEBUG_LOG: /dev/stdout
         XDEBUG_LOG_LEVEL: 0
+    ports:
+      - '${VITE_PORT:-5173}:5173'
     tty: true  # Enables an interactive terminal
     stdin_open: true  # Keeps standard input open for 'docker exec'
     env_file:

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,12 @@ import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
 
 export default defineConfig({
+    server: {
+        host: '0.0.0.0',
+        hmr: {
+            host: 'localhost',
+        }
+    },
     plugins: [
         laravel({
             input: ['resources/css/app.css', 'resources/js/app.js'],


### PR DESCRIPTION
Sorry, I had to open a new pull request. Something went wrong I guess. However, I fixed the problem and tested as you suggested. And this solution is working out of box for users. Thanks! @rw4lll 