### PR TITLE
Fix PHP-FPM status path configuration

### DIFF
--- a/docker/common/php-fpm/Dockerfile
+++ b/docker/common/php-fpm/Dockerfile
@@ -92,8 +92,8 @@ COPY --from=builder /usr/local/bin/docker-php-ext-* /usr/local/bin/
 # -----------------------------------------------------------
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
-# Enable PHP-FPM status page by modifying zz-docker.conf with sed
-RUN sed -i '/\[www\]/a pm.status_path = /status' /usr/local/etc/php-fpm.d/zz-docker.conf
+# Keep the image-provided FPM global config intact and add pool overrides separately
+COPY ./docker/common/php-fpm/conf.d/*.conf /usr/local/etc/php-fpm.d/
 # Update the variables_order to include E (for ENV)
 #RUN sed -i 's/variables_order = "GPCS"/variables_order = "EGPCS"/' "$PHP_INI_DIR/php.ini"
 

--- a/docker/common/php-fpm/conf.d/20-status-path.conf
+++ b/docker/common/php-fpm/conf.d/20-status-path.conf
@@ -1,0 +1,2 @@
+[www]
+pm.status_path = /status


### PR DESCRIPTION
This pull request updates the configuration of PHP-FPM in the Docker setup to improve maintainability and separation of concerns. The main change is moving the status path configuration from an inline modification in the Dockerfile to a dedicated configuration file.

Configuration management improvements:

* The `pm.status_path = /status` setting for the PHP-FPM status page is now specified in a new pool override file, `20-status-path.conf`, instead of being added by a `sed` command in the Dockerfile.
* The Dockerfile (`docker/common/php-fpm/Dockerfile`) now copies all configuration overrides from `docker/common/php-fpm/conf.d/` into the appropriate directory, keeping the image-provided FPM global configuration intact and making pool-specific overrides easier to manage.

This fixes #18 thanks to @jeffbrl and @prokushka for pointing this out. Used approach with dedicated conf file, as recommended by Docker [here](https://hub.docker.com/_/php).