### PR TITLE
Remove chown on php-fpm entrypoint script

### DIFF
--- a/docker/development/php-fpm/entrypoint.sh
+++ b/docker/development/php-fpm/entrypoint.sh
@@ -1,14 +1,6 @@
 #!/bin/sh
 set -e
 
-# Check if $UID and $GID are set, else fallback to default (1000:1000)
-USER_ID=${UID:-1000}
-GROUP_ID=${GID:-1000}
-
-# Fix file ownership and permissions using the passed UID and GID
-echo "Fixing file permissions with UID=${USER_ID} and GID=${GROUP_ID}..."
-chown -R ${USER_ID}:${GROUP_ID} /var/www || echo "Some files could not be changed"
-
 # Clear configurations to avoid caching issues in development
 echo "Clearing configurations..."
 php artisan config:clear


### PR DESCRIPTION
This pull request makes a minor update to the `docker/development/php-fpm/entrypoint.sh` script by removing the logic that adjusted file ownership and permissions based on the provided `UID` and `GID` environment variables. The script now only clears Laravel configurations to avoid caching issues in development.

- Removed logic for setting file ownership and permissions using `UID` and `GID` environment variables.